### PR TITLE
ETL pipe for relational DB creation

### DIFF
--- a/backend/data/db.py
+++ b/backend/data/db.py
@@ -47,7 +47,7 @@ class Album(Base):
     artist = relationship("Artist", back_populates="albums")
     tracks = relationship("Track", back_populates="album")
 
-class Song(Base):
+class Track(Base):
     """Main songs table storing basic song metadata."""
     __tablename__ = "tracks"
 

--- a/backend/data/ingest_relational_DB.py
+++ b/backend/data/ingest_relational_DB.py
@@ -2,7 +2,6 @@
 ETL for MSD → relational DB.
 
 Phases: HDF5 core → Last.fm/tags → musiXmatch.
-Updated parser for official lastfm_train.txt/test.txt (tab-separated).
 Usage:
     python ingest_msd.py --h5_dir /path/to/MillionSongSubset \
         --db_url sqlite:///echoagent.db
@@ -10,13 +9,14 @@ Usage:
 
 import os
 import argparse
+import json
 import h5py
 import pandas as pd
 from pathlib import Path
 from tqdm import tqdm
-from typing import Dict, Any, Optional
-import tables  # For HDF5
+from typing import Any
 import sqlite3
+from sqlalchemy.exc import IntegrityError
 
 from db import (
     get_db_session,
@@ -30,30 +30,22 @@ from db import (
 
 def parse_h5_file(h5_path: Path, session: Any) -> None:
     """Parse single HDF5 → insert artist/album/track/audio."""
+
+    tid = h5_path.stem  # Use HDF5 filename as track_id
     with h5py.File(h5_path, 'r') as f:
         songs = f['metadata/songs'][:]
-        track_ids = songs['track_id'].astype(str)
+        song_data = {k: songs[k][0] for k in songs.dtype.names if k != 'song_id'}
         
-        for i, tid in enumerate(track_ids):
-            song_data = {k.decode(): v[i] for k, v in songs.items() if k != 'track_id'}
-            
-            # Artist (skip if no ID)
-            artist_id = song_data.get('artist_id')
-            if artist_id is not None:
-                artist_id_str = (
-                    artist_id.decode('utf-8')
-                    if isinstance(artist_id, bytes)
-                    else str(artist_id)
-                )
-                artist_name = song_data.get('artist_name')
-                artist_name_str = (
-                    artist_name.decode('utf-8')
-                    if isinstance(artist_name, bytes)
-                    else str(artist_name)
-                    if artist_name is not None
-                    else ''
-                )
+        # Artist (skip if no ID)
+        artist_id = song_data.get('artist_id')
+        if artist_id is not None:
+            artist_id_str = str(artist_id).strip()
+            artist_name = song_data.get('artist_name')
+            artist_name_str = str(artist_name) if artist_name is not None else ''
 
+            # Check if artist already exists and ingest if not
+            existing = session.query(Artist).filter_by(artist_id=artist_id_str).first()
+            if not existing:
                 session.merge(
                     Artist(
                         artist_id=artist_id_str,
@@ -75,155 +67,94 @@ def parse_h5_file(h5_path: Path, session: Any) -> None:
                         ),
                     )
                 )
+        
+        # Album (surrogate ID: artist_release_title, since MSD has no stable album PK)
+        release = song_data.get('release')
+        release_str = str(release) if release is not None else ''
+        year = int(song_data.get('year', 0)) if song_data.get('year') is not None else None
+        
+        release_id = None
+        if artist_id_str and release_str:
+            release_id = (
+                f"{artist_id_str}_{release_str.replace(' ', '_')[:50]}"
+            )  # Truncate long titles
             
-            # Album (surrogate ID: artist_release_title)
-            release = song_data.get('release')
-            release_str = (
-                release.decode('utf-8')
-                if isinstance(release, bytes)
-                else str(release)
-                if release is not None
-                else None
-            )
-            year = int(song_data.get('year', 0)) if song_data.get('year') is not None else None
-            
-            release_id = None
-            if artist_id_str and release_str:
-                release_id = (
-                    f"{artist_id_str}_{release_str.replace(' ', '_')[:50]}"
-                )  # Truncate long titles
-                
-                session.merge(Album(
-                    release_id=release_id,
-                    title=release_str,
-                    year=year,
-                    artist_id=artist_id_str
-                ))
-            
-            # Track base
-            title = song_data.get('title')
-            title_str = (
-                title.decode('utf-8')
-                if isinstance(title, bytes)
-                else str(title)
-                if title is not None
-                else ''
-            )
-            
-            track = Track(
-                track_id=tid.decode('utf-8'),
-                title=title_str,
-                artist_id=artist_id_str or '',
+            session.merge(Album(
                 release_id=release_id,
-                seed_genre=None,  # Phase 2
-                top_tags_json=None  # Phase 2
-            )
-            session.merge(track)
-            
-            # Audio features
-            analysis_group = f.get('analysis', None)
-            if analysis_group and 'songs' in analysis_group:
-                try:
-                    analysis = analysis_group['songs'][i]
-                    af_data = {}
-                    for field in [
-                        'duration',
-                        'key',
-                        'key_confidence',
-                        'loudness',
-                        'mode',
-                        'mode_confidence',
-                        'tempo',
-                        'time_signature',
-                        'time_signature_confidence',
-                        'danceability',
-                        'energy',
-                    ]:
-                        val = analysis.get(field, None)
-                        af_data[field] = float(val) if val is not None else None
-                    
-                    af = AudioFeature(track_id=tid.decode('utf-8'), **af_data)
-                    session.merge(af)
-                except Exception as e:
-                    print(f"Warning: Could not parse analysis for {tid}: {e}")
+                title=release_str,
+                year=year,
+                artist_id=artist_id_str
+            ))
+        
+        # Track base row points to artist/album and leaves tag/genre fields for later phases
+        title = song_data.get('title')
+        title_str = str(title) if title is not None else ''
+        
+        track = Track(
+            track_id=str(tid),
+            title=title_str,
+            artist_id=artist_id_str or '',
+            release_id=release_id,
+            seed_genre=None,  # Phase 2
+            top_tags_json=None  # Phase 2
+        )
+        session.merge(track)
+        
+        # Audio features
+        analysis_group = f.get('analysis', None)
+        if analysis_group and 'songs' in analysis_group:
+            try:
+                analysis_songs = analysis_group['songs'][:]
+                analysis_row = analysis_songs[0]
+                af_data = {}
+                for field in [
+                    'duration',
+                    'key',
+                    'key_confidence',
+                    'loudness',
+                    'mode',
+                    'mode_confidence',
+                    'tempo',
+                    'time_signature',
+                    'time_signature_confidence',
+                    'danceability',
+                    'energy',
+                ]:
+                    val = analysis_row[field] if field in analysis_row.dtype.names else None
+                    af_data[field] = float(val) if val is not None else None
+                
+                af = AudioFeature(track_id=str(tid), **af_data)
+                session.merge(af)
+            except Exception as e:
+                print(f"Warning: Could not parse analysis for {tid}: {e}")
 
 def ingest_h5_dir(h5_dir: Path, db_url: str, batch_size: int = 100) -> None:
-    """Ingest all HDF5 files."""
+    """Ingest all HDF5 files for core metadata + audio features."""
+    # Walk the MSD subset tree and collect all HDF5 files once up front
     h5_files = list(h5_dir.rglob("*.h5"))
     print(f"Found {len(h5_files)} HDF5 files.")
     
+    # Use a single DBSession; commit per file for safety (no batch-level data loss)
     with DBSession(db_url) as session:
         pbar = tqdm(h5_files, desc="HDF5 files")
         for h5_path in pbar:
-            parse_h5_file(h5_path, session)
-            if len(session.new) >= batch_size:
+            try:
+                # Parse and upsert a single track worth of rows
+                parse_h5_file(h5_path, session)
+                # Commit immediately so that a failure only affects this file
                 session.commit()
+            except IntegrityError as e:
+                # Most likely a duplicate PK or FK issue for this specific file
+                session.rollback()
+                print(f"⚠️ IntegrityError for {h5_path} — skipping file: {e}")
+            except Exception as e:
+                # Any other parsing/DB error is logged and the file is skipped
+                session.rollback()
+                print(f"Error parsing {h5_path}: {e}")
+            finally:
+                # Detach objects from the session to keep memory usage bounded
                 session.expunge_all()
-                pbar.set_postfix(batch=f"{len(session.new)}")
-        session.commit()
-    print("Phase 1 complete: Core metadata + audio features.")
-
-def ingest_lastfm_tags(lastfm_dir: Path, db_url: str) -> None:
-    """Ingest Last.fm tags from official train.txt + test.txt (tab-separated)."""
-    tags_data = {}
-    
-    for txt_file in lastfm_dir.glob("lastfm_*.txt"):
-        print(f"Parsing {txt_file.name}...")
-        with open(txt_file, 'r', encoding='utf-8', errors='ignore') as f:
-            lines = f.readlines()
-            pbar = tqdm(
-                lines,
-                desc=f"{txt_file.name}",
-                unit='lines',
-                total=len(lines),
-            )
-            for line in pbar:
-                parts = line.strip().split('\t')
-                if len(parts) >= 4:
-                    tid, artist, title, tags_str = parts[0:4]
-                    
-                    tags = {}
-                    if tags_str and tags_str.strip() and tags_str != '""':
-                        # Unquote if needed
-                        if tags_str.startswith('"') and tags_str.endswith('"'):
-                            tags_str = tags_str[1:-1]
-                        # Parse "tag1:w1;tag2:w2"
-                        for tag_w in tags_str.split(';'):
-                            tag_w = tag_w.strip()
-                            if ':' in tag_w:
-                                tag, w_str = tag_w.rsplit(':', 1)
-                                try:
-                                    tags[tag.strip()] = float(w_str.strip())
-                                except ValueError:
-                                    continue
-                    
-                    if tags:  # Only store if has meaningful tags
-                        tags_data[tid] = {k: v for k, v in tags.items() if v > 0}
-        
-        print(f"{txt_file.name}: {len(tags_data)} unique tagged tracks so far.")
-    
-    print(f"Total: {len(tags_data)} tagged tracks loaded.")
-    
-    # Update tracks
-    with DBSession(db_url) as session:
-        tracks = (
-            session.query(Track.track_id, Track)
-            .filter(Track.track_id.in_(list(tags_data.keys())))
-            .all()
-        )
-        track_dict = {tid: track for tid, track in tracks}
-        
-        updates = 0
-        for tid, tags in tqdm(
-            tags_data.items(),
-            desc="Updating tags",
-        ):
-            if tid in track_dict:
-                track_dict[tid].top_tags_json = tags
-                updates += 1
-        
-        session.commit()
-        print(f"Updated {updates} tracks with Last.fm tags.")
+    print("✅ Ingested core metadata + audio features from MSD.")
 
 def ingest_lastfm_json_subset(json_base_dir: Path, db_url: str) -> None:
     """
@@ -231,31 +162,42 @@ def ingest_lastfm_json_subset(json_base_dir: Path, db_url: str) -> None:
     AdditionalFiles/A/AA0/AA0000000.json → tags for matching .h5 track.
     JSON format: {"track_id": "...", "tags": [...], "tag_weights": [...]}
     """
+    # Accumulate tags per track_id before a single DB pass
     tags_data = {}
     
-    # Walk parallel to HDF5: A/AA0/AA0000000.json
+    # Mirror the MSD subset folder structure (A/B/C/...) for Last.fm JSON sidecar files
     json_files = list(json_base_dir.rglob("*.json"))
     print(f"Found {len(json_files)} Last.fm JSON files.")
     
     for json_path in tqdm(json_files, desc="JSON tags"):
         try:
-            data = pd.read_json(json_path, typ='series')  # Single track JSON
-            
-            tid = data.get('track_id', '')
+            data_raw = json_path.read_text(errors='ignore')
+            data = json.loads(data_raw)
+            tid = data.get('track_id', '').strip()
+            if not tid:
+                continue
+                
             tags = data.get('tags', [])
-            weights = data.get('tag_weights', [])
-            
-            if tid and tags and len(tags) == len(weights):
-                tag_dict = {tag: float(w) for tag, w in zip(tags, weights) if float(w) > 0}
+            if isinstance(tags, list) and tags:
+                weights = data.get('tag_weights', [])
+                tag_dict = {}
+                # Keep at most the top 50 tags per track to bound JSON size
+                for j, tag in enumerate(tags[:50]):
+                    w = float(weights[j]) if j < len(weights) else 1.0
+                    if w > 0:
+                        tag_dict[str(tag)] = w
+                
                 if tag_dict:
                     tags_data[tid] = tag_dict
                     
+        except json.JSONDecodeError:
+            continue
         except Exception as e:
-            print(f"Warning: Skip {json_path}: {e}")
+            print(f"Skip {json_path.name}: {type(e).__name__}")
     
     print(f"Loaded {len(tags_data)} tagged tracks from JSON.")
     
-    # Update DB (same as text parser)
+    # Single pass over the DB to attach Last.fm tags to existing tracks
     with DBSession(db_url) as session:
         tracks = {t.track_id: t for t in session.query(Track).all()}
         updates = 0
@@ -264,20 +206,22 @@ def ingest_lastfm_json_subset(json_base_dir: Path, db_url: str) -> None:
                 tracks[tid].top_tags_json = tags
                 updates += 1
         session.commit()
-    print(f"Updated {updates} tracks with subset JSON tags.")        
+    print(f"✅ Updated {updates} tracks with Last.fm JSON tags.")        
 
 def ingest_musixmatch_sqlite(db_path: Path, msd_db_url: str) -> None:
-    """Query MXM SQLite directly for existing track_ids."""
+    """Query MXM SQLite directly and attach lyrics BoW to known MSD tracks."""
     print(f"Loading lyrics from {db_path}...")
     conn = sqlite3.connect(db_path)
     cursor = conn.cursor()
     
-    # Get relational track_ids
+    # Only request lyrics for tracks we already ingested into the relational DB
     with DBSession(msd_db_url) as session:
         track_ids = [t.track_id for t in session.query(Track.track_id).all()]
     
+    # Build an in-memory mapping of track_id → {word: count}
     lyrics_data = {}
     for tid in tqdm(track_ids, desc="MXM SQLite query"):
+        # MXM schema stores one (track_id, word, count) row per non-zero entry
         cursor.execute("""
             SELECT word, count FROM lyrics 
             WHERE track_id = ? AND count > 0
@@ -286,15 +230,14 @@ def ingest_musixmatch_sqlite(db_path: Path, msd_db_url: str) -> None:
         if bow:
             lyrics_data[tid] = bow
     
-    # Insert
+    # Insert lyrics rows once we have the complete BoW for each track
     with DBSession(msd_db_url) as session:
         for tid, bow in tqdm(lyrics_data.items(), desc="Insert BoW"):
             session.merge(Lyrics(track_id=tid, bow_vector=bow))
         session.commit()
     
     conn.close()
-    print(f"✅ Inserted {len(lyrics_data)} lyrics BoW.")
-
+    print(f"✅ Ingested {len(lyrics_data)} MXM BoW lyrics.")
 
 def ingest_genres(cls_file: Path, db_url: str) -> None:
     """Ingest seed_genre from msd_lastfm_map.cls → Track.seed_genre."""
@@ -325,13 +268,12 @@ def ingest_genres(cls_file: Path, db_url: str) -> None:
                 tracks[tid].seed_genre = genre
                 updates += 1
         session.commit()
-        print(f"✅ Updated {updates} tracks with seed_genre from .cls.")
+        print(f"✅ Ingested {updates} tracks with seed_genre from tagtraum.")
 
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="MSD ETL Pipeline")
     parser.add_argument("--h5_dir", required=True, help="Path to HDF5 directory")
-    parser.add_argument("--lastfm_dir", help="Dir with lastfm_*.txt (full MSD)")
     parser.add_argument("--lastfm_json_dir", help="Dir with Last.fm JSON (subset, parallel to h5)")
     parser.add_argument("--mxm_sqlite", help="Path to mxm_dataset.db (REQUIRED for lyrics)")
     parser.add_argument("--lastfm_map", help="Path to msd_lastfm_map.cls (REQUIRED for genres)")
@@ -342,13 +284,11 @@ if __name__ == "__main__":
     # Phase 1: Core (always)
     ingest_h5_dir(Path(args.h5_dir), args.db_url, args.batch_size)
     
-    # Phase 2: Tags (text OR JSON)
-    if args.lastfm_dir and Path(args.lastfm_dir).exists():
-        ingest_lastfm_tags(Path(args.lastfm_dir), args.db_url)
-    elif args.lastfm_json_dir and Path(args.lastfm_json_dir).exists():
+    # Phase 2: Tags (JSON subset only)
+    if args.lastfm_json_dir and Path(args.lastfm_json_dir).exists():
         ingest_lastfm_json_subset(Path(args.lastfm_json_dir), args.db_url)
     else:
-        print("⚠️ Skip tags: Need --lastfm_dir OR --lastfm_json_dir")
+        print("⚠️ Skip tags: Need --lastfm_json_dir (Last.fm JSON subset)")
     
     # Phase 3: Lyrics (SQLite only)
     if args.mxm_sqlite and Path(args.mxm_sqlite).exists():

--- a/backend/data/ingest_relational_DB.py
+++ b/backend/data/ingest_relational_DB.py
@@ -297,9 +297,36 @@ def ingest_musixmatch_sqlite(db_path: Path, msd_db_url: str) -> None:
 
 
 def ingest_genres(cls_file: Path, db_url: str) -> None:
-    """Ingest seed_genre from msd_lastfm_map.cls (placeholder—adjust format)."""
-    print("Genres ingestion: TBD (custom parser for .cls format needed).")
-    # TODO: Implement based on exact .cls format from tagtraum
+    """Ingest seed_genre from msd_lastfm_map.cls → Track.seed_genre."""
+    print(f"Parsing genres from {cls_file}...")
+    genres_data = {}
+    
+    with open(cls_file, 'r') as f:
+        for line_num, line in enumerate(tqdm(f, desc="Last.fm map .cls")):
+            line = line.strip()
+            if not line or line.startswith('#'):  # Skip comments/empty
+                continue
+                
+            # Format: track_id genre [other_tags...]
+            # e.g. "TRABC123 rock alternative indie"
+            parts = line.split()
+            if len(parts) >= 2:
+                tid = parts[0]
+                seed_genre = parts[1]  # First = seed genre
+                genres_data[tid] = seed_genre
+    
+    print(f"Loaded {len(genres_data)} genre mappings.")
+    
+    with DBSession(db_url) as session:
+        tracks = {t.track_id: t for t in session.query(Track).all()}
+        updates = 0
+        for tid, genre in tqdm(genres_data.items(), desc="Updating seed_genre"):
+            if tid in tracks:
+                tracks[tid].seed_genre = genre
+                updates += 1
+        session.commit()
+        print(f"✅ Updated {updates} tracks with seed_genre from .cls.")
+
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="MSD ETL Pipeline")
@@ -307,6 +334,7 @@ if __name__ == "__main__":
     parser.add_argument("--lastfm_dir", help="Dir with lastfm_*.txt (full MSD)")
     parser.add_argument("--lastfm_json_dir", help="Dir with Last.fm JSON (subset, parallel to h5)")
     parser.add_argument("--mxm_sqlite", help="Path to mxm_dataset.db (REQUIRED for lyrics)")
+    parser.add_argument("--lastfm_map", help="Path to msd_lastfm_map.cls (REQUIRED for genres)")
     parser.add_argument("--db_url", default="sqlite:///echoagent.db")
     parser.add_argument("--batch_size", type=int, default=100)
     args = parser.parse_args()
@@ -327,5 +355,11 @@ if __name__ == "__main__":
         ingest_musixmatch_sqlite(Path(args.mxm_sqlite), args.db_url)
     else:
         print("⚠️ Skip lyrics: --mxm_sqlite REQUIRED (mxm_dataset.db)")
-    
+        
+    # Phase 4: Genres (cls file)
+    if args.lastfm_map and Path(args.lastfm_map).exists():
+        ingest_genres(Path(args.lastfm_map), args.db_url)
+    else:
+        print("⚠️ Skip genres: --lastfm_map Data/msd_lastfm_map.cls")
+
     print("✅ ETL complete!")

--- a/notebooks/relational_DB_ingestion_runner.ipynb
+++ b/notebooks/relational_DB_ingestion_runner.ipynb
@@ -1,0 +1,359 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "72560ef7",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "/Users/dc1408/side_hustle/EchoAgent/backend/data\n",
+      "✅ Working dir: /Users/dc1408/side_hustle/EchoAgent/backend/data\n",
+      "✅ DB path: music_relational.db\n",
+      "Database initialized at: sqlite:///music_relational.db\n"
+     ]
+    }
+   ],
+   "source": [
+    "#Setup paths + imports\n",
+    "%cd ../backend/data\n",
+    "import sys\n",
+    "import os\n",
+    "sys.path.append(os.path.abspath('.'))\n",
+    "\n",
+    "from db import DBSession, Track, init_db\n",
+    "from ingest_relational_DB import ingest_h5_dir, ingest_lastfm_json_subset, ingest_musixmatch_sqlite, ingest_genres\n",
+    "from pathlib import Path\n",
+    "import sqlite3\n",
+    "\n",
+    "print(\"✅ Working dir:\", os.getcwd())\n",
+    "print(\"✅ DB path:\", \"music_relational.db\")\n",
+    "\n",
+    "# Paths from backend/data/\n",
+    "H5_DIR = \"../../../Data/MillionSongSubset\"\n",
+    "LASTFM_JSON_DIR = \"../../../Data/lastfm_subset\"\n",
+    "MXM_DB = \"../../../Data/mxm_dataset.db\"\n",
+    "LASTFM_MAP = \"../../../Data/msd_lastfm_map.cls\"\n",
+    "DB_URL = \"sqlite:///music_relational.db\"\n",
+    "\n",
+    "# Init DB\n",
+    "init_db(DB_URL)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "d9991a38",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Database initialized at: sqlite:///music_relational.db\n",
+      "🧹 DB reset!\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Nuke everything to start afresh\n",
+    "\n",
+    "from db import init_db, DBSession, Base, Track, Artist, Album, AudioFeature, Lyrics\n",
+    "from sqlalchemy import create_engine\n",
+    "\n",
+    "engine = create_engine(DB_URL)\n",
+    "Base.metadata.drop_all(engine)\n",
+    "init_db(DB_URL)\n",
+    "print(\"🧹 DB reset!\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "c1e7b639",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Found 10000 HDF5 files.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "HDF5 files: 100%|██████████| 10000/10000 [00:20<00:00, 489.08it/s]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Ingested core metadata + audio features from MSD.\n",
+      "Tracks loaded: 10000\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Phase 1 - Core track/artist/album/audio feature data from MSD HDF5 files\n",
+    "\n",
+    "ingest_h5_dir(Path(H5_DIR), DB_URL)\n",
+    "\n",
+    "# Quick check\n",
+    "with DBSession(DB_URL) as s:\n",
+    "    print(\"Tracks loaded:\", s.query(Track).count())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "d3b3fe4b",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ 10000 tracks, 3888 artists\n",
+      "Audio features: 10000\n",
+      "Albums: 8061\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Counting total tracks/artists/audio features/albums to sanity check ingestion looks reasonable\n",
+    "\n",
+    "with DBSession(DB_URL) as s:\n",
+    "    total = s.query(Track).count()\n",
+    "    print(f\"✅ {total} tracks, {s.query(Artist).count()} artists\")\n",
+    "    print(f\"Audio features: {s.query(AudioFeature).count()}\")\n",
+    "    print(f\"Albums: {s.query(Album).count()}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "f0f9d0f5",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Found 9330 Last.fm JSON files.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "JSON tags: 100%|██████████| 9330/9330 [00:00<00:00, 10491.83it/s]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Loaded 4833 tagged tracks from JSON.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Updating JSON tags: 100%|██████████| 4833/4833 [00:00<00:00, 1222916.94it/s]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Updated 4833 tracks with Last.fm JSON tags.\n",
+      "Tracks with non-empty tags: 4833\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Phase 2 - Last.fm tags (JSON subset)\n",
+    "\n",
+    "ingest_lastfm_json_subset(Path(LASTFM_JSON_DIR), DB_URL)\n",
+    "\n",
+    "with DBSession(DB_URL) as s:\n",
+    "    tags_count = (\n",
+    "        s.query(Track)\n",
+    "        .filter(Track.top_tags_json != 'null')  # SQLite stores JSON null as the string \"null\"\n",
+    "        .count()\n",
+    "    )\n",
+    "    print(f\"Tracks with non-empty tags: {tags_count}\")\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "3126e50b",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Loading lyrics from ../../../Data/mxm_dataset.db...\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "MXM SQLite query:   0%|          | 0/10000 [00:00<?, ?it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "MXM SQLite query: 100%|██████████| 10000/10000 [00:00<00:00, 39905.96it/s]\n",
+      "Insert BoW: 100%|██████████| 2350/2350 [00:00<00:00, 8973.77it/s]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Ingested 2350 MXM BoW lyrics.\n",
+      "Lyrics BoW: 2350\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Phase 3 - Lyrics (MXM BoW from SQLite)\n",
+    "ingest_musixmatch_sqlite(Path(MXM_DB), DB_URL)\n",
+    "\n",
+    "with DBSession(DB_URL) as s:\n",
+    "    print(\"Lyrics BoW:\", s.query(Lyrics).count())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "ddb94cc5",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Parsing genres from ../../../Data/msd_lastfm_map.cls...\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Last.fm map .cls: 505223it [00:00, 763867.05it/s]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Loaded 505216 genre mappings.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Updating seed_genre: 100%|██████████| 505216/505216 [00:00<00:00, 9189598.38it/s]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Ingested 4833 tracks with seed_genre from tagtraum.\n",
+      "Tracks with seed_genre: 4833\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Phase 4 - Seed genres\n",
+    "ingest_genres(Path(LASTFM_MAP), DB_URL)\n",
+    "\n",
+    "with DBSession(DB_URL) as s:\n",
+    "    print(\"Tracks with seed_genre:\", s.query(Track).filter(Track.seed_genre.isnot(None)).count())\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "daea428a",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Sample tagged tracks:\n",
+      "TRARROY128F4... | tags: [] | seed: 'None'\n",
+      "TRARRER128F9... | tags: [\"['chill', '100']\", \"['Fusion', '100']\"] | seed: 'chill'\n",
+      "TRARRZU128F4... | tags: [\"['on the road', '100']\", \"['Titletracks', '100']\"] | seed: 'ontheroad'\n",
+      "TRARUDQ128F9... | tags: [] | seed: 'None'\n",
+      "TRARREF128F4... | tags: [\"['punk', '100']\", \"['halloween', '52']\", \"['punk rock', '40']\"] | seed: 'rock'\n",
+      "TRARRMK12903... | tags: [\"['Sludge', '100']\", \"['doom metal', '100']\", \"['grindcore', '100']\"] | seed: 'freejazz'\n",
+      "TRARRJL128F9... | tags: [\"['french', '100']\", \"['menu du jour', '25']\", \"['bright voice', '25']\"] | seed: 'french'\n",
+      "TRARUOP12903... | tags: [\"['metalcore', '100']\", \"['metal', '81']\", \"['thrash metal', '62']\"] | seed: 'hardcore'\n",
+      "TRARRWA128F4... | tags: [\"['post-hardcore', '100']\", \"['hardcore-punk', '100']\"] | seed: 'hardcore'\n",
+      "TRARURM128F9... | tags: [] | seed: 'None'\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Randomly sample some tracks with tags to verify they look reasonable\n",
+    "\n",
+    "from random import sample\n",
+    "\n",
+    "with DBSession(DB_URL) as s:\n",
+    "    tagged = s.query(Track).filter(Track.top_tags_json.isnot(None)).limit(20).all()\n",
+    "    \n",
+    "    print(\"Sample tagged tracks:\")\n",
+    "    for t in sample(tagged, min(10, len(tagged))):\n",
+    "        tags = t.top_tags_json or {}\n",
+    "        genre = t.seed_genre\n",
+    "        print(f\"{t.track_id[:12]}... | tags: {list(tags.keys())[:3]} | seed: '{genre}'\")\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.14"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
- Updated the HDF5 parsing logic to streamline artist and album ingestion, ensuring proper handling of existing records.
- Improved error handling for audio feature extraction.
- Introduced a new Jupyter notebook for running the relational DB ingestion pipeline, including steps for initializing the database and ingesting data from various sources (HDF5, Last.fm JSON, MXM lyrics, and genre mappings).
- Added functionality to reset the database before ingestion to ensure a clean state.